### PR TITLE
Fix installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install Date
+    $ gem install date
 
 ## Usage
 


### PR DESCRIPTION
This gem is 'date', not a 'Date'.
```
$ gem install Date
ERROR:  Could not find a valid gem 'Date' (>= 0) in any repository
ERROR:  Possible alternatives: date
```