### PR TITLE
Make julian dates roundtrip through to_time.to_date

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -8555,17 +8555,24 @@ time_to_datetime(VALUE self)
  * call-seq:
  *    d.to_time  ->  time
  *
- * Returns a Time object which denotes self.
+ * Returns a Time object which denotes self. If self is a julian date,
+ * convert it to a gregorian date before converting it to Time.
  */
 static VALUE
 date_to_time(VALUE self)
 {
-    get_d1(self);
+    get_d1a(self);
+
+    if (m_julian_p(adat)) {
+        VALUE tmp = d_lite_gregorian(self);
+        get_d1b(tmp);
+        adat = bdat;
+    }
 
     return f_local3(rb_cTime,
-		    m_real_year(dat),
-		    INT2FIX(m_mon(dat)),
-		    INT2FIX(m_mday(dat)));
+        m_real_year(adat),
+        INT2FIX(m_mon(adat)),
+        INT2FIX(m_mday(adat)));
 }
 
 /*

--- a/test/date/test_date_conv.rb
+++ b/test/date/test_date_conv.rb
@@ -48,6 +48,24 @@ class TestDateConv < Test::Unit::TestCase
 		 [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.usec])
   end
 
+  def test_to_time_to_date_roundtrip__from_gregorian_date
+    d = Date.new(1582, 10, 15)
+    t = d.to_time
+    assert_equal([1582, 10, 15, 0, 0, 0, 0],
+		 [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.usec])
+    assert_equal(d, t.to_date)
+    assert_equal(d.jd, t.to_date.jd)
+  end
+
+  def test_to_time_to_date_roundtrip__from_julian_date
+    d = Date.new(1582, 10, 4)
+    t = d.to_time
+    assert_equal([1582, 10, 14, 0, 0, 0, 0],
+		 [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.usec])
+    assert_equal(d, t.to_date)
+    assert_equal(d.jd, t.to_date.jd)
+  end
+
   def test_to_time__from_datetime
     d = DateTime.new(2004, 9, 19, 1, 2, 3, 8.to_r/24) + 456789.to_r/86400000000
     t = d.to_time


### PR DESCRIPTION
Previously, julian dates would not round trip through to_time.to_date,
because Time is always considered gregorian.  This converts the Date
instance from julian to gregorian before converting to Time, ensuring
that an equal date object will be returned if converting that Time
back to Date.

This does result in julian Date objects showing different day values
if converting to Time.

Fixes Ruby Bug 8428.