### PR TITLE
introduce Date::InvalidDateError, DateTime::InvalidDateTimeError

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -22,6 +22,7 @@
 
 static ID id_cmp, id_le_p, id_ge_p, id_eqeq_p;
 static VALUE cDate, cDateTime;
+static VALUE eDateError;
 static VALUE half_days_in_day, day_in_nanoseconds;
 static double positive_inf, negative_inf;
 
@@ -3069,7 +3070,7 @@ old_to_new(VALUE ajd, VALUE of, VALUE sg,
     *rsg = NUM2DBL(sg);
 
     if (*rdf < 0 || *rdf >= DAY_IN_SECONDS)
-	rb_raise(rb_eArgError, "invalid day fraction");
+	rb_raise(eDateError, "invalid day fraction");
 
     if (f_lt_p(*rsf, INT2FIX(0)) ||
 	f_ge_p(*rsf, INT2FIX(SECOND_IN_NANOSECONDS)))
@@ -3231,7 +3232,7 @@ do {\
     s = s##_trunc(v##s, &fr);\
     if (f_nonzero_p(fr)) {\
 	if (argc > n)\
-	    rb_raise(rb_eArgError, "invalid fraction");\
+	    rb_raise(eDateError, "invalid fraction");\
 	fr2 = fr;\
     }\
 } while (0)
@@ -3241,7 +3242,7 @@ do {\
     s = NUM2INT(s##_trunc(v##s, &fr));\
     if (f_nonzero_p(fr)) {\
 	if (argc > n)\
-	    rb_raise(rb_eArgError, "invalid fraction");\
+	    rb_raise(eDateError, "invalid fraction");\
 	fr2 = fr;\
     }\
 } while (0)
@@ -3368,7 +3369,7 @@ date_s_ordinal(int argc, VALUE *argv, VALUE klass)
 			     &nth, &ry,
 			     &rd, &rjd,
 			     &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	ret = d_simple_new_internal(klass,
 				     nth, rjd,
@@ -3452,7 +3453,7 @@ date_initialize(int argc, VALUE *argv, VALUE self)
 	if (!valid_gregorian_p(y, m, d,
 			       &nth, &ry,
 			       &rm, &rd))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	set_to_simple(self, dat, nth, 0, sg, ry, rm, rd, HAVE_CIVIL);
     }
@@ -3464,7 +3465,7 @@ date_initialize(int argc, VALUE *argv, VALUE self)
 			   &nth, &ry,
 			   &rm, &rd, &rjd,
 			   &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	set_to_simple(self, dat, nth, rjd, sg, ry, rm, rd, HAVE_JD | HAVE_CIVIL);
     }
@@ -3526,7 +3527,7 @@ date_s_commercial(int argc, VALUE *argv, VALUE klass)
 				&nth, &ry,
 				&rw, &rd, &rjd,
 				&ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	ret = d_simple_new_internal(klass,
 				    nth, rjd,
@@ -3576,7 +3577,7 @@ date_s_weeknum(int argc, VALUE *argv, VALUE klass)
 			     &nth, &ry,
 			     &rw, &rd, &rjd,
 			     &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	ret = d_simple_new_internal(klass,
 				    nth, rjd,
@@ -3625,7 +3626,7 @@ date_s_nth_kday(int argc, VALUE *argv, VALUE klass)
 			      &nth, &ry,
 			      &rm, &rn, &rk, &rjd,
 			      &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	ret = d_simple_new_internal(klass,
 				    nth, rjd,
@@ -4172,7 +4173,7 @@ d_new_by_frags(VALUE klass, VALUE hash, VALUE sg)
     }
 
     if (NIL_P(hash))
-	rb_raise(rb_eArgError, "invalid date");
+	rb_raise(eDateError, "invalid date");
 
     if (NIL_P(ref_hash("jd")) &&
 	NIL_P(ref_hash("yday")) &&
@@ -4189,7 +4190,7 @@ d_new_by_frags(VALUE klass, VALUE hash, VALUE sg)
     }
 
     if (NIL_P(jd))
-	rb_raise(rb_eArgError, "invalid date");
+	rb_raise(eDateError, "invalid date");
     {
 	VALUE nth;
 	int rjd;
@@ -4752,11 +4753,11 @@ d_lite_initialize(int argc, VALUE *argv, VALUE self)
 	sf = vsf;
 	if (f_lt_p(sf, INT2FIX(0)) ||
 	    f_ge_p(sf, INT2FIX(SECOND_IN_NANOSECONDS)))
-	    rb_raise(rb_eArgError, "invalid second fraction");
+	    rb_raise(eDateError, "invalid second fraction");
       case 2:
 	df = NUM2INT(vdf);
 	if (df < 0 || df >= DAY_IN_SECONDS)
-	    rb_raise(rb_eArgError, "invalid day fraction");
+	    rb_raise(eDateError, "invalid day fraction");
       case 1:
 	jd = vjd;
     }
@@ -6067,7 +6068,7 @@ d_lite_rshift(VALUE self, VALUE other)
 			  &rm, &rd, &rjd, &ns))
 	    break;
 	if (--d < 1)
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
     }
     encode_jd(nth, rjd, &rjd2);
     return d_lite_plus(self, f_sub(rjd2, m_real_local_jd(dat)));
@@ -7287,7 +7288,7 @@ datetime_s_jd(int argc, VALUE *argv, VALUE klass)
 	int rh, rmin, rs, rjd, rjd2;
 
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	decode_jd(jd, &nth, &rjd);
@@ -7366,9 +7367,9 @@ datetime_s_ordinal(int argc, VALUE *argv, VALUE klass)
 			     &nth, &ry,
 			     &rd, &rjd,
 			     &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	rjd2 = jd_local_to_utc(rjd,
@@ -7461,9 +7462,9 @@ datetime_initialize(int argc, VALUE *argv, VALUE self)
 	if (!valid_gregorian_p(y, m, d,
 			       &nth, &ry,
 			       &rm, &rd))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	set_to_complex(self, dat,
@@ -7482,9 +7483,9 @@ datetime_initialize(int argc, VALUE *argv, VALUE self)
 			   &nth, &ry,
 			   &rm, &rd, &rjd,
 			   &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	rjd2 = jd_local_to_utc(rjd,
@@ -7566,9 +7567,9 @@ datetime_s_commercial(int argc, VALUE *argv, VALUE klass)
 				&nth, &ry,
 				&rw, &rd, &rjd,
 				&ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	rjd2 = jd_local_to_utc(rjd,
@@ -7637,9 +7638,9 @@ datetime_s_weeknum(int argc, VALUE *argv, VALUE klass)
 			     &nth, &ry,
 			     &rw, &rd, &rjd,
 			     &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	rjd2 = jd_local_to_utc(rjd,
@@ -7706,9 +7707,9 @@ datetime_s_nth_kday(int argc, VALUE *argv, VALUE klass)
 			      &nth, &ry,
 			      &rm, &rn, &rk, &rjd,
 			      &ns))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	if (!c_valid_time_p(h, min, s, &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 	canon24oc();
 
 	rjd2 = jd_local_to_utc(rjd,
@@ -7851,7 +7852,7 @@ dt_new_by_frags(VALUE klass, VALUE hash, VALUE sg)
     }
 
     if (NIL_P(hash))
-	rb_raise(rb_eArgError, "invalid date");
+	rb_raise(eDateError, "invalid date");
 
     if (NIL_P(ref_hash("jd")) &&
 	NIL_P(ref_hash("yday")) &&
@@ -7878,7 +7879,7 @@ dt_new_by_frags(VALUE klass, VALUE hash, VALUE sg)
     }
 
     if (NIL_P(jd))
-	rb_raise(rb_eArgError, "invalid date");
+	rb_raise(eDateError, "invalid date");
 
     {
 	int rh, rmin, rs;
@@ -7887,7 +7888,7 @@ dt_new_by_frags(VALUE klass, VALUE hash, VALUE sg)
 			    NUM2INT(ref_hash("min")),
 			    NUM2INT(ref_hash("sec")),
 			    &rh, &rmin, &rs))
-	    rb_raise(rb_eArgError, "invalid date");
+	    rb_raise(eDateError, "invalid date");
 
 	df = time_to_df(rh, rmin, rs);
     }
@@ -9275,6 +9276,7 @@ Init_date_core(void)
      *
      */
     cDate = rb_define_class("Date", rb_cObject);
+    eDateError = rb_define_class_under(cDate, "Error", rb_eArgError);
 
     rb_include_module(cDate, rb_mComparable);
 

--- a/test/date/test_date_new.rb
+++ b/test/date/test_date_new.rb
@@ -27,7 +27,7 @@ class TestDateNew < Test::Unit::TestCase
   end
 
   def test_jd__ex
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.jd(0, 23,59,60,0)
     end
   end
@@ -118,10 +118,10 @@ class TestDateNew < Test::Unit::TestCase
   end
 
   def test_ordinal__ex
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.ordinal(2001,366)
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.ordinal(2001,365, 23,59,60, 0)
     end
   end
@@ -177,13 +177,13 @@ class TestDateNew < Test::Unit::TestCase
   end
 
   def test_civil__ex
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.civil(2001,2,29)
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.civil(2001,2,28, 23,59,60, 0)
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.civil(2001,2,28, 24,59,59, 0)
     end
   end
@@ -244,10 +244,10 @@ class TestDateNew < Test::Unit::TestCase
   end
 
   def test_commercial__ex
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.commercial(1997,53,1)
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.commercial(1997,52,1, 23,59,60, 0)
     end
   end
@@ -266,10 +266,10 @@ class TestDateNew < Test::Unit::TestCase
     assert_equal(2452355, d.jd)
     assert_equal([11,22,33], [d.hour, d.min, d.sec])
 
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.weeknum(1999,53,0, 0)
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.weeknum(1999,-53,-1, 0)
     end
   end if Date.respond_to?(:weeknum, true)
@@ -288,10 +288,10 @@ class TestDateNew < Test::Unit::TestCase
     assert_equal(2448682, d.jd)
     assert_equal([11,22,33], [d.hour, d.min, d.sec])
 
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.nth_kday(2006,5, 5,0)
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.nth_kday(2006,5, -5,0)
     end
   end if Date.respond_to?(:nth_kday, true)

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -660,26 +660,38 @@ class TestDateParse < Test::Unit::TestCase
   end
 
   def test_parse__ex
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.parse('')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.parse('')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.parse('2001-02-29')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.parse('2001-02-29T23:59:60')
     end
-    assert_nothing_raised(ArgumentError) do
+    assert_nothing_raised(Date::Error) do
       DateTime.parse('2001-03-01T23:59:60')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.parse('2001-03-01T23:59:61')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.parse('23:55')
+    end
+
+    begin
+      Date.parse('')
+    rescue ArgumentError => e
+      assert e.is_a? Date::Error
+    end
+
+    begin
+      DateTime.parse('')
+    rescue ArgumentError => e
+      assert e.is_a? Date::Error
     end
   end
 

--- a/test/date/test_date_strptime.rb
+++ b/test/date/test_date_strptime.rb
@@ -459,28 +459,28 @@ class TestDateStrptime < Test::Unit::TestCase
   end
 
   def test_strptime__ex
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.strptime('')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.strptime('')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.strptime('2001-02-29', '%F')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.strptime('2001-02-29T23:59:60', '%FT%T')
     end
-    assert_nothing_raised(ArgumentError) do
+    assert_nothing_raised(Date::Error) do
       DateTime.strptime('2001-03-01T23:59:60', '%FT%T')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       DateTime.strptime('2001-03-01T23:59:61', '%FT%T')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.strptime('23:55', '%H:%M')
     end
-    assert_raise(ArgumentError) do
+    assert_raise(Date::Error) do
       Date.strptime('01-31-2011', '%m/%d/%Y')
     end
   end


### PR DESCRIPTION
all too often i see and write the following:

```rb
def foobar value
  Date.parse value
rescue ArgumentError => e
  if e.message == "invalid date"
    # handle that invalid date
  else
    raise
  end
end
```

with this patch this code will still work (because `Date::InvalidDateError < ArgumentError`) but can become this:

```rb
def foobar value
  Date.parse value
rescue Date::InvalidDateError
  # handle that invalid date
end
```

i think `ArgumentError` is far too generic for the case of failing because of an invalid date and we are dealing with dates quite often. that's why i want to introduce a more specific error type to make it easier to target that case in code bases and not running the risk of rescuing unrelated `ArgumentError`'s with `rescue ArgumentError` when actually just wanting to deal with an invalid date that we get from user-input.

there also is a `DateTime::InvalidDateTimeError` class which works exactly the same:

```rb
def foobar value
  DateTime.parse value
rescue DateTime::InvalidDateTimeError
  # handle that invalid date
end
```

what do you think?