### PR TITLE
Simplify #inspect

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6560,9 +6560,9 @@ mk_inspect(union DateData *x, VALUE klass, VALUE to_s)
  * Returns the value as a string for inspection.
  *
  *    Date.new(2001,2,3).inspect
- *		#=> "#<Date: 2001-02-03 ((2451944j,0s,0n),+0s,2299161j)>"
+ *		#=> "#<Date: 2001-02-03>"
  *    DateTime.new(2001,2,3,4,5,6,'-7').inspect
- *		#=> "#<DateTime: 2001-02-03T04:05:06-07:00 ((2451944j,39906s,0n),-25200s,2299161j)>"
+ *		#=> "#<DateTime: 2001-02-03T04:05:06-07:00>"
  */
 static VALUE
 d_lite_inspect(VALUE self)

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6549,11 +6549,8 @@ static VALUE
 mk_inspect(union DateData *x, VALUE klass, VALUE to_s)
 {
     return rb_enc_sprintf(rb_usascii_encoding(),
-			  "#<%"PRIsVALUE": %"PRIsVALUE" "
-			  "((%+"PRIsVALUE"j,%ds,%+"PRIsVALUE"n),%+ds,%.0fj)>",
-			  klass, to_s,
-			  m_real_jd(x), m_df(x), m_sf(x),
-			  m_of(x), m_sg(x));
+			  "#<%"PRIsVALUE": %"PRIsVALUE">",
+			  klass, to_s);
 }
 
 /*

--- a/test/date/test_switch_hitter.rb
+++ b/test/date/test_switch_hitter.rb
@@ -282,8 +282,10 @@ class TestSH < Test::Unit::TestCase
   def test_inspect
     d = Date.new(2001, 2, 3)
     assert_equal(Encoding::US_ASCII, d.inspect.encoding)
+    assert_equal('#<Date: 2001-02-03>', d.inspect)
     d = DateTime.new(2001, 2, 3)
     assert_equal(Encoding::US_ASCII, d.inspect.encoding)
+    assert_equal('#<DateTime: 2001-02-03T00:00:00+00:00>', d.inspect)
   end
 
   def test_strftime


### PR DESCRIPTION
I'd like to raise a discussion on the following change:

```ruby
# before:
Date.new(2010, 1, 3).inspect
# => #<Date: 2010-01-03 ((2455200j,0s,0n),+0s,2299161j)> 

# after:
Date.new(2010, 1, 3).inspect
# => #<Date: 2010-01-03> 
```

Justification: for most of contexts where `Date` could be used (web apps, data conversion scripts, experiments and so on), the "((2455200j,0s,0n),+0s,2299161j)" suffix is meaningless, and just obscures the data reading. Imagine the (pretty simple) example:
```ruby
# before
(1..10).map { |days| Date.today - days }
# => [#<Date: 2019-08-10 ((2458706j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-09 ((2458705j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-08 ((2458704j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-07 ((2458703j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-06 ((2458702j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-05 ((2458701j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-04 ((2458700j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-03 ((2458699j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-02 ((2458698j,0s,0n),+0s,2299161j)>, #<Date: 2019-08-01 ((2458697j,0s,0n),+0s,2299161j)>]

# after:
(1..10).map { |days| Date.today - days }
 => [#<Date: 2019-08-10>, #<Date: 2019-08-09>, #<Date: 2019-08-08>, #<Date: 2019-08-07>, #<Date: 2019-08-06>, #<Date: 2019-08-05>, #<Date: 2019-08-04>, #<Date: 2019-08-03>, #<Date: 2019-08-02>, #<Date: 2019-08-01>]
```

Whether it is a list of dates we extract from DB, or have in test (of some scheduling library), or parse from CSV, I believe the "before" example is very hard to read and provides no additional value.

On the other hand, for the rare contexts when values like "julian day number" matter, the `((2458697j,0s,0n),+0s,2299161j)` format seem to be too terse to be easily used by anybody not 200% familiar with library's internals.