### PR TITLE
Remove taint support

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -4244,12 +4244,10 @@ date_s__strptime_internal(int argc, VALUE *argv, VALUE klass,
 
 	if (!NIL_P(zone)) {
 	    rb_enc_copy(zone, vstr);
-	    OBJ_INFECT(zone, vstr);
 	    set_hash("zone", zone);
 	}
 	if (!NIL_P(left)) {
 	    rb_enc_copy(left, vstr);
-	    OBJ_INFECT(left, vstr);
 	    set_hash("leftover", left);
 	}
     }
@@ -4733,7 +4731,6 @@ d_lite_initialize(int argc, VALUE *argv, VALUE self)
     double sg;
 
     rb_check_frozen(self);
-    rb_check_trusted(self);
 
     rb_scan_args(argc, argv, "05", &vjd, &vdf, &vsf, &vof, &vsg);
 
@@ -4789,7 +4786,6 @@ static VALUE
 d_lite_initialize_copy(VALUE copy, VALUE date)
 {
     rb_check_frozen(copy);
-    rb_check_trusted(copy);
 
     if (copy == date)
 	return copy;
@@ -6762,7 +6758,6 @@ date_strftime_internal(int argc, VALUE *argv, VALUE self,
 	    if (p > fmt) rb_str_cat(str, fmt, p - fmt);
 	}
 	rb_enc_copy(str, vfmt);
-	OBJ_INFECT(str, vfmt);
 	return str;
     }
     else
@@ -6771,7 +6766,6 @@ date_strftime_internal(int argc, VALUE *argv, VALUE self,
     str = rb_str_new(buf, len);
     if (buf != buffer) xfree(buf);
     rb_enc_copy(str, vfmt);
-    OBJ_INFECT(str, vfmt);
     return str;
 }
 
@@ -7162,7 +7156,6 @@ d_lite_marshal_load(VALUE self, VALUE a)
     get_d1(self);
 
     rb_check_frozen(self);
-    rb_check_trusted(self);
 
     if (!RB_TYPE_P(a, T_ARRAY))
 	rb_raise(rb_eTypeError, "expected an array");

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -421,10 +421,9 @@ class TestDateParse < Test::Unit::TestCase
       l = format('<failed at line %d>', l)
       assert_equal(y, a, l)
       if y[6]
-        h = Date._parse(x[0].dup.taint, *x[1..-1])
+        h = Date._parse(x[0].dup, *x[1..-1])
         assert_equal(y[6], h[:zone], l)
         assert_equal(y[6].encoding, h[:zone].encoding, l)
-        assert_predicate(h[:zone], :tainted?, l)
       end
     end
   end

--- a/test/date/test_switch_hitter.rb
+++ b/test/date/test_switch_hitter.rb
@@ -568,35 +568,6 @@ class TestSH < Test::Unit::TestCase
     assert_equal(Date::GREGORIAN, d.start)
   end
 
-  def test_taint
-    h = Date._strptime('15:43+09:00', '%R%z')
-    assert_equal(false, h[:zone].tainted?)
-    h = Date._strptime('15:43+09:00'.dup.taint, '%R%z')
-    assert_equal(true, h[:zone].tainted?)
-
-    h = Date._strptime('1;1/0', '%d')
-    assert_equal(false, h[:leftover].tainted?)
-    h = Date._strptime('1;1/0'.dup.taint, '%d')
-    assert_equal(true, h[:leftover].tainted?)
-
-    h = Date._parse('15:43+09:00')
-    assert_equal(false, h[:zone].tainted?)
-    h = Date._parse('15:43+09:00'.dup.taint)
-    assert_equal(true, h[:zone].tainted?)
-
-    s = Date.today.strftime('new 105')
-    assert_equal(false, s.tainted?)
-    s = Date.today.strftime('new 105'.dup.taint)
-    assert_equal(true, s.tainted?)
-    s = Date.today.strftime("new \000 105".dup.taint)
-    assert_equal(true, s.tainted?)
-
-    s = DateTime.now.strftime('super $record')
-    assert_equal(false, s.tainted?)
-    s = DateTime.now.strftime('super $record'.dup.taint)
-    assert_equal(true, s.tainted?)
-  end
-
   def test_enc
     Date::MONTHNAMES.each do |s|
       assert_equal(Encoding::US_ASCII, s.encoding) if s


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
The lack of taint support should not cause a problem in
previous versions.