### PR TITLE
Fix typo causing Date.new(year, month) to fail

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -3438,7 +3438,7 @@ date_initialize(int argc, VALUE *argv, VALUE self)
         check_numeric(vd, "day");
 	num2int_with_frac(d, positive_inf);
       case 2:
-        check_numeric(vd, "month");
+        check_numeric(vm, "month");
 	m = NUM2INT(vm);
       case 1:
         check_numeric(vy, "year");

--- a/test/date/test_date_new.rb
+++ b/test/date/test_date_new.rb
@@ -165,6 +165,10 @@ class TestDateNew < Test::Unit::TestCase
     assert_equal([2001, 2, 3, 4, 5, 6, 0],
 		 [d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.offset])
     assert_equal(1.to_r/2, d.sec_fraction)
+
+    d = DateTime.civil(2001, 2)
+    assert_equal([2001, 2, 1, 0, 0, 0, 0],
+		 [d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.offset])
   end
 
   def test_civil__neg


### PR DESCRIPTION
Add a test for this case.

This has alread been committed to ruby/ruby.