### PR TITLE
No need to include Comparable into an already Comparable class Date::Infinity

### DIFF
--- a/lib/date.rb
+++ b/lib/date.rb
@@ -11,8 +11,6 @@ class Date
 
   class Infinity < Numeric # :nodoc:
 
-    include Comparable
-
     def initialize(d=1) @d = d <=> 0 end
 
     def d() @d end


### PR DESCRIPTION
Because Date::Infinity inherits from Numeric that includes Comparable.