### PR TITLE
Make %v strftime flag use uppercase month

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6900,7 +6900,7 @@ date_strftime_internal(int argc, VALUE *argv, VALUE self,
  *      %c - date and time (%a %b %e %T %Y)
  *      %D - Date (%m/%d/%y)
  *      %F - The ISO 8601 date format (%Y-%m-%d)
- *      %v - VMS date (%e-%b-%Y)
+ *      %v - VMS date (%e-%^b-%Y)
  *      %x - Same as %D
  *      %X - Same as %T
  *      %r - 12-hour time (%I:%M:%S %p)
@@ -8380,7 +8380,7 @@ dt_lite_to_s(VALUE self)
  *      %c - date and time (%a %b %e %T %Y)
  *      %D - Date (%m/%d/%y)
  *      %F - The ISO 8601 date format (%Y-%m-%d)
- *      %v - VMS date (%e-%b-%Y)
+ *      %v - VMS date (%e-%^b-%Y)
  *      %x - Same as %D
  *      %X - Same as %T
  *      %r - 12-hour time (%I:%M:%S %p)

--- a/ext/date/date_strftime.c
+++ b/ext/date/date_strftime.c
@@ -393,7 +393,7 @@ date_strftime_with_tmx(char *s, const size_t maxsize, const char *format,
 	    continue;
 
 	  case 'v':
-	    STRFTIME("%e-%b-%Y");
+	    STRFTIME("%e-%^b-%Y");
 	    continue;
 
 	  case 'w':	/* weekday, Sunday == 0, 0 - 6 */

--- a/test/date/test_date_strftime.rb
+++ b/test/date/test_date_strftime.rb
@@ -48,7 +48,7 @@ class TestDateStrftime < Test::Unit::TestCase
     '%t'=>["\t",{}],
     '%u'=>['6',{:cwday=>6}],
     '%V'=>['05',{:cweek=>5}],
-    '%v'=>[' 3-Feb-2001',{:mday=>3,:mon=>2,:year=>2001}],
+    '%v'=>[' 3-FEB-2001',{:mday=>3,:mon=>2,:year=>2001}],
     '%z'=>['+0000',{:zone=>'+0000',:offset=>0}],
     '%+'=>['Sat Feb  3 00:00:00 +00:00 2001',
       {:wday=>6,:mon=>2,:mday=>3,


### PR DESCRIPTION
%v is supposed to be the VMS date, and VMS date format uses an
uppercase month.

Ruby 1.8 used an uppercase month for %v, but the behavior was
changed without explanation in r31672.

Time#strftime still uses an uppercase month for %v, so this change
makes Date#strftime consistent with Time#strftime.

Fixes [Bug #13810]