### PR TITLE
`Date._<format>(nil)` should return an empty Hash

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -4342,6 +4342,8 @@ get_limit(VALUE opt)
 static void
 check_limit(VALUE str, VALUE opt)
 {
+    if (NIL_P(str)) return;
+
     StringValue(str);
     size_t slen = RSTRING_LEN(str);
     size_t limit = get_limit(opt);

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -4343,6 +4343,7 @@ static void
 check_limit(VALUE str, VALUE opt)
 {
     if (NIL_P(str)) return;
+    if (SYMBOL_P(str)) str = rb_sym2str(str);
 
     StringValue(str);
     size_t slen = RSTRING_LEN(str);

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -848,6 +848,9 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._iso8601('')
     assert_equal({}, h)
+
+    h = Date._iso8601(nil)
+    assert_equal({}, h)
   end
 
   def test__rfc3339
@@ -862,6 +865,9 @@ class TestDateParse < Test::Unit::TestCase
 		 h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
 
     h = Date._rfc3339('')
+    assert_equal({}, h)
+
+    h = Date._rfc3339(nil)
     assert_equal({}, h)
   end
 
@@ -945,6 +951,9 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._xmlschema('')
     assert_equal({}, h)
+
+    h = Date._xmlschema(nil)
+    assert_equal({}, h)
   end
 
   def test__rfc2822
@@ -977,6 +986,9 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._rfc2822('')
     assert_equal({}, h)
+
+    h = Date._rfc2822(nil)
+    assert_equal({}, h)
   end
 
   def test__httpdate
@@ -996,6 +1008,9 @@ class TestDateParse < Test::Unit::TestCase
 		 h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
 
     h = Date._httpdate('')
+    assert_equal({}, h)
+
+    h = Date._httpdate(nil)
     assert_equal({}, h)
   end
 
@@ -1072,6 +1087,9 @@ class TestDateParse < Test::Unit::TestCase
 		 h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
 
     h = Date._jisx0301('')
+    assert_equal({}, h)
+
+    h = Date._jisx0301(nil)
     assert_equal({}, h)
   end
 

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -851,6 +851,10 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._iso8601(nil)
     assert_equal({}, h)
+
+    h = Date._iso8601('01-02-03T04:05:06Z'.to_sym)
+    assert_equal([2001, 2, 3, 4, 5, 6, 0],
+      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
 
   def test__rfc3339
@@ -869,6 +873,10 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._rfc3339(nil)
     assert_equal({}, h)
+
+    h = Date._rfc3339('2001-02-03T04:05:06Z'.to_sym)
+    assert_equal([2001, 2, 3, 4, 5, 6, 0],
+      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
 
   def test__xmlschema
@@ -954,6 +962,10 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._xmlschema(nil)
     assert_equal({}, h)
+
+    h = Date._xmlschema('2001-02-03'.to_sym)
+    assert_equal([2001, 2, 3, nil, nil, nil, nil],
+      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
 
   def test__rfc2822
@@ -989,6 +1001,10 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._rfc2822(nil)
     assert_equal({}, h)
+
+    h = Date._rfc2822('Sat, 3 Feb 2001 04:05:06 UT'.to_sym)
+    assert_equal([2001, 2, 3, 4, 5, 6, 0],
+      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
 
   def test__httpdate
@@ -1012,6 +1028,10 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._httpdate(nil)
     assert_equal({}, h)
+
+    h = Date._httpdate('Sat, 03 Feb 2001 04:05:06 GMT'.to_sym)
+    assert_equal([2001, 2, 3, 4, 5, 6, 0],
+      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
 
   def test__jisx0301
@@ -1091,6 +1111,10 @@ class TestDateParse < Test::Unit::TestCase
 
     h = Date._jisx0301(nil)
     assert_equal({}, h)
+
+    h = Date._jisx0301('H13.02.03T04:05:06.07+0100'.to_sym)
+    assert_equal([2001, 2, 3, 4, 5, 6, 3600],
+      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
 
   def test_iso8601


### PR DESCRIPTION
Fix: https://github.com/ruby/date/issues/39

This is how versions previous to 3.2.1 behaved and Active Support
currently rely on this behavior.

https://github.com/rails/rails/blob/90357af08048ef5076730505f6e7b14a81f33d0c/activesupport/lib/active_support/values/time_zone.rb#L383-L384

Any Rails application upgrading to date `3.2.1` might run into unexpected errors.