### PR TITLE
Expose Date::VERSION

### DIFF
--- a/date.gemspec
+++ b/date.gemspec
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
+
+version = File.foreach(File.expand_path("../lib/date.rb", __FILE__)).find do |line|
+  /^\s*VERSION\s*=\s*["'](.*)["']/ =~ line and break $1
+end
+
 Gem::Specification.new do |s|
   s.name = "date"
-  s.version = '3.2.1'
+  s.version = version
   s.summary = "A subclass of Object includes Comparable module for handling dates."
   s.description = "A subclass of Object includes Comparable module for handling dates."
 

--- a/lib/date.rb
+++ b/lib/date.rb
@@ -4,6 +4,7 @@
 require 'date_core'
 
 class Date
+  VERSION = '3.2.1' # :nodoc:
 
   def infinite?
     false


### PR DESCRIPTION
An almost universal convention for gems is to expose `Namespace::VERSION`
which makes it mcuh easier when debugging etc.

Many gems extracted from ruby don't do this, even though it would be even more
useful because they ship with ruby, so it's less clear which version it is.

cc @mame 