### PR TITLE
Match only non-empty version string

### DIFF
--- a/date.gemspec
+++ b/date.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 version = File.foreach(File.expand_path("../lib/date.rb", __FILE__)).find do |line|
-  /^\s*VERSION\s*=\s*["'](.*)["']/ =~ line and break $1
+  /^\s*VERSION\s*=\s*["']([^'"]+)/ =~ line and break $1
 end
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
The current regular expression accepts empty version strings, ``VERSION = ''``, and extra characters until the final string delimiter character, even after a comment, ``VERSION = '3.2.1' # comment'``.
Currently the VERSION line is ``VERSION = '3.2.1' # :nodoc:``, which means another string delimiter may appear in the comment in the future.