### PR TITLE
Deprecate the unintentional ability to parse `Symbol`

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -4339,11 +4339,19 @@ get_limit(VALUE opt)
     return 128;
 }
 
+#ifndef HAVE_RB_CATEGORY_WARN
+#define rb_category_warn(category, fmt) rb_warn(fmt)
+#endif
+
 static void
 check_limit(VALUE str, VALUE opt)
 {
     if (NIL_P(str)) return;
-    if (SYMBOL_P(str)) str = rb_sym2str(str);
+    if (SYMBOL_P(str)) {
+	rb_category_warn(RB_WARN_CATEGORY_DEPRECATED,
+			 "The ability to parse Symbol is an unintentional bug and is deprecated");
+	str = rb_sym2str(str);
+    }
 
     StringValue(str);
     size_t slen = RSTRING_LEN(str);

--- a/ext/date/extconf.rb
+++ b/ext/date/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 
 config_string("strict_warnflags") {|w| $warnflags += " #{w}"}
 
+have_func("rb_category_warn")
 with_werror("", {:werror => true}) do |opt, |
   have_var("timezone", "time.h", opt)
   have_var("altzone", "time.h", opt)

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -852,7 +852,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._iso8601(nil)
     assert_equal({}, h)
 
-    h = Date._iso8601('01-02-03T04:05:06Z'.to_sym)
+    h = assert_warn(/deprecated/) {Date._iso8601('01-02-03T04:05:06Z'.to_sym)}
     assert_equal([2001, 2, 3, 4, 5, 6, 0],
       h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
@@ -874,7 +874,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._rfc3339(nil)
     assert_equal({}, h)
 
-    h = Date._rfc3339('2001-02-03T04:05:06Z'.to_sym)
+    h = assert_warn(/deprecated/) {Date._rfc3339('2001-02-03T04:05:06Z'.to_sym)}
     assert_equal([2001, 2, 3, 4, 5, 6, 0],
       h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
@@ -963,7 +963,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._xmlschema(nil)
     assert_equal({}, h)
 
-    h = Date._xmlschema('2001-02-03'.to_sym)
+    h = assert_warn(/deprecated/) {Date._xmlschema('2001-02-03'.to_sym)}
     assert_equal([2001, 2, 3, nil, nil, nil, nil],
       h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
@@ -1002,7 +1002,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._rfc2822(nil)
     assert_equal({}, h)
 
-    h = Date._rfc2822('Sat, 3 Feb 2001 04:05:06 UT'.to_sym)
+    h = assert_warn(/deprecated/) {Date._rfc2822('Sat, 3 Feb 2001 04:05:06 UT'.to_sym)}
     assert_equal([2001, 2, 3, 4, 5, 6, 0],
       h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
@@ -1029,7 +1029,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._httpdate(nil)
     assert_equal({}, h)
 
-    h = Date._httpdate('Sat, 03 Feb 2001 04:05:06 GMT'.to_sym)
+    h = assert_warn(/deprecated/) {Date._httpdate('Sat, 03 Feb 2001 04:05:06 GMT'.to_sym)}
     assert_equal([2001, 2, 3, 4, 5, 6, 0],
       h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end
@@ -1112,7 +1112,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._jisx0301(nil)
     assert_equal({}, h)
 
-    h = Date._jisx0301('H13.02.03T04:05:06.07+0100'.to_sym)
+    h = assert_warn(/deprecated/) {Date._jisx0301('H13.02.03T04:05:06.07+0100'.to_sym)}
     assert_equal([2001, 2, 3, 4, 5, 6, 3600],
       h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
   end


### PR DESCRIPTION
I don't think date-formatted symbols make sense.