### PR TITLE
Suppress declaration-after-statement warnings

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -4342,12 +4342,13 @@ get_limit(VALUE opt)
 static void
 check_limit(VALUE str, VALUE opt)
 {
+    size_t slen, limit;
     if (NIL_P(str)) return;
     if (SYMBOL_P(str)) str = rb_sym2str(str);
 
     StringValue(str);
-    size_t slen = RSTRING_LEN(str);
-    size_t limit = get_limit(opt);
+    slen = RSTRING_LEN(str);
+    limit = get_limit(opt);
     if (slen > limit) {
 	rb_raise(rb_eArgError,
 		 "string length (%"PRI_SIZE_PREFIX"u) exceeds the limit %"PRI_SIZE_PREFIX"u", slen, limit);
@@ -4445,11 +4446,11 @@ date_s_parse(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 2;
-	VALUE argv2[3];
+	VALUE argv2[3], hash;
         argv2[0] = str;
         argv2[1] = comp;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__parse(argc2, argv2, klass);
+	hash = date_s__parse(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -4514,10 +4515,10 @@ date_s_iso8601(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__iso8601(argc2, argv2, klass);
+	hash = date_s__iso8601(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -4573,10 +4574,10 @@ date_s_rfc3339(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__rfc3339(argc2, argv2, klass);
+	hash = date_s__rfc3339(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -4632,10 +4633,10 @@ date_s_xmlschema(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__xmlschema(argc2, argv2, klass);
+	hash = date_s__xmlschema(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -4693,10 +4694,10 @@ date_s_rfc2822(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__rfc2822(argc2, argv2, klass);
+	hash = date_s__rfc2822(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -4752,10 +4753,10 @@ date_s_httpdate(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__httpdate(argc2, argv2, klass);
+	hash = date_s__httpdate(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -4815,10 +4816,10 @@ date_s_jisx0301(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         if (!NIL_P(opt)) argv2[argc2++] = opt;
-	VALUE hash = date_s__jisx0301(argc2, argv2, klass);
+	hash = date_s__jisx0301(argc2, argv2, klass);
 	return d_new_by_frags(klass, hash, sg);
     }
 }
@@ -8200,12 +8201,12 @@ datetime_s_parse(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 2;
-        VALUE argv2[3];
+        VALUE argv2[3], hash;
         argv2[0] = str;
         argv2[1] = comp;
         argv2[2] = opt;
         if (!NIL_P(opt)) argc2++;
-	VALUE hash = date_s__parse(argc2, argv2, klass);
+	hash = date_s__parse(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }
@@ -8245,11 +8246,11 @@ datetime_s_iso8601(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
         if (!NIL_P(opt)) argc2--;
-	VALUE hash = date_s__iso8601(argc2, argv2, klass);
+	hash = date_s__iso8601(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }
@@ -8285,11 +8286,11 @@ datetime_s_rfc3339(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
         if (!NIL_P(opt)) argc2++;
-	VALUE hash = date_s__rfc3339(argc2, argv2, klass);
+	hash = date_s__rfc3339(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }
@@ -8325,11 +8326,11 @@ datetime_s_xmlschema(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
         if (!NIL_P(opt)) argc2++;
-	VALUE hash = date_s__xmlschema(argc2, argv2, klass);
+	hash = date_s__xmlschema(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }
@@ -8366,11 +8367,11 @@ datetime_s_rfc2822(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
         if (!NIL_P(opt)) argc2++;
-	VALUE hash = date_s__rfc2822(argc2, argv2, klass);
+	hash = date_s__rfc2822(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }
@@ -8406,11 +8407,11 @@ datetime_s_httpdate(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
         if (!NIL_P(opt)) argc2++;
-	VALUE hash = date_s__httpdate(argc2, argv2, klass);
+	hash = date_s__httpdate(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }
@@ -8451,11 +8452,11 @@ datetime_s_jisx0301(int argc, VALUE *argv, VALUE klass)
 
     {
         int argc2 = 1;
-        VALUE argv2[2];
+        VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
         if (!NIL_P(opt)) argc2++;
-	VALUE hash = date_s__jisx0301(argc2, argv2, klass);
+	hash = date_s__jisx0301(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }
 }


### PR DESCRIPTION
Date gem still supports rubies older than 2.7, which assume C89.