### PR TITLE
d_lite_zero

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -9113,7 +9113,31 @@ mk_ary_of_str(long len, const char *a[])
 }
 
 static VALUE
-d_lite_zero(VALUE x)
+d_lite_hour(VALUE x)
+{
+    return INT2FIX(0);
+}
+
+static VALUE
+d_lite_min(VALUE x)
+{
+    return INT2FIX(0);
+}
+
+static VALUE
+d_lite_minute(VALUE x)
+{
+    return INT2FIX(0);
+}
+
+static VALUE
+d_lite_sec(VALUE x)
+{
+    return INT2FIX(0);
+}
+
+static VALUE
+d_lite_second(VALUE x)
 {
     return INT2FIX(0);
 }
@@ -9509,11 +9533,11 @@ Init_date_core(void)
     rb_define_method(cDate, "nth_kday?", d_lite_nth_kday_p, 2);
 #endif
 
-    rb_define_private_method(cDate, "hour", d_lite_zero, 0);
-    rb_define_private_method(cDate, "min", d_lite_zero, 0);
-    rb_define_private_method(cDate, "minute", d_lite_zero, 0);
-    rb_define_private_method(cDate, "sec", d_lite_zero, 0);
-    rb_define_private_method(cDate, "second", d_lite_zero, 0);
+    rb_define_private_method(cDate, "hour", d_lite_hour, 0);
+    rb_define_private_method(cDate, "min", d_lite_min, 0);
+    rb_define_private_method(cDate, "minute", d_lite_minute, 0);
+    rb_define_private_method(cDate, "sec", d_lite_sec, 0);
+    rb_define_private_method(cDate, "second", d_lite_second, 0);
 
     rb_define_method(cDate, "julian?", d_lite_julian_p, 0);
     rb_define_method(cDate, "gregorian?", d_lite_gregorian_p, 0);


### PR DESCRIPTION
Five private methods were hooked up to d_lite_zero (having to do with hour, minute, second).  The first one, #hour, was suppressed in the RDoc, but the other four were not suppressed and were included in the RDoc as aliases for #hour.  This may be a bug in RDoc (private alias of private method not suppressed).  I have repaired it here by creating five methods to replace d_lite_zero.