### PR TITLE
[DOC] Enhanced RDoc

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -9112,6 +9112,7 @@ mk_ary_of_str(long len, const char *a[])
     return o;
 }
 
+/* :nodoc: */
 static VALUE
 d_lite_zero(VALUE x)
 {


### PR DESCRIPTION
Omit private aliases from Rdoc.

RDoc incorrectly includes private aliases of a private method.  This prevents that error.