### PR TITLE
The shrunk words to be copied is limited

### DIFF
--- a/ext/date/date_parse.c
+++ b/ext/date/date_parse.c
@@ -442,14 +442,14 @@ date_zone_to_diff(VALUE str)
 	{
 	    const char *zn = s;
 	    long sl = shrunk_size(s, l);
-	    VALUE vbuf = 0;
+	    char shrunk_buff[MAX_WORD_LENGTH]; /* no terminator to be added */
 	    const struct zone *z = 0;
 
 	    if (sl <= 0) {
 		sl = l;
 	    }
 	    else if (sl <= MAX_WORD_LENGTH) {
-		char *d = ALLOCV_N(char, vbuf, sl);
+		char *d = shrunk_buff;
 		sl = shrink_space(d, s, l);
 		zn = d;
 	    }
@@ -457,7 +457,6 @@ date_zone_to_diff(VALUE str)
 	    if (sl > 0 && sl <= MAX_WORD_LENGTH) {
 		z = zonetab(zn, (unsigned int)sl);
 	    }
-	    ALLOCV_END(vbuf);
 
 	    if (z) {
 		int d = z->offset;

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -41,6 +41,7 @@ class TestDateParse < Test::Unit::TestCase
      [['Sat Aug 28 02:29:34 Mountain Daylight Time 2000',false],[2000,8,28,2,29,34,'Mountain Daylight Time',-6*3600,6], __LINE__],
      [['Sat Aug 28 02:29:34 Mexico Standard Time 2000',false],[2000,8,28,2,29,34,'Mexico Standard Time',-6*3600,6], __LINE__],
      [['Sat Aug 28 02:29:34 E. Australia Standard Time 2000',false],[2000,8,28,2,29,34,'E. Australia Standard Time',10*3600,6], __LINE__],
+     [['Sat Aug 28 02:29:34 W.  Central  Africa  Standard  Time 2000',false],[2000,8,28,2,29,34,'W. Central Africa Standard Time',1*3600,6], __LINE__],
 
      # part of iso 8601
      [['1999-05-23 23:55:21',false],[1999,5,23,23,55,21,nil,nil,nil], __LINE__],


### PR DESCRIPTION
Th buffer size is small enough and no need to allocate dynamically.