### PR TITLE
No-op gem for JRuby for now

### DIFF
--- a/date.gemspec
+++ b/date.gemspec
@@ -10,14 +10,21 @@ Gem::Specification.new do |s|
   s.summary = "A subclass of Object includes Comparable module for handling dates."
   s.description = "A subclass of Object includes Comparable module for handling dates."
 
-  s.require_path = %w{lib}
-  s.files = [
-    "README.md",
-    "lib/date.rb", "ext/date/date_core.c", "ext/date/date_parse.c", "ext/date/date_strftime.c",
-    "ext/date/date_strptime.c", "ext/date/date_tmx.h", "ext/date/extconf.rb", "ext/date/prereq.mk",
-    "ext/date/zonetab.h", "ext/date/zonetab.list"
-  ]
-  s.extensions = "ext/date/extconf.rb"
+  if Gem::Platform === s.platform and s.platform =~ 'java' or RUBY_ENGINE == 'jruby'
+    s.platform = 'java'
+    # No files shipped, no require path, no-op for now on JRuby
+  else
+    s.require_path = %w{lib}
+
+    s.files = [
+      "README.md",
+      "lib/date.rb", "ext/date/date_core.c", "ext/date/date_parse.c", "ext/date/date_strftime.c",
+      "ext/date/date_strptime.c", "ext/date/date_tmx.h", "ext/date/extconf.rb", "ext/date/prereq.mk",
+      "ext/date/zonetab.h", "ext/date/zonetab.list"
+    ]
+    s.extensions = "ext/date/extconf.rb"
+  end
+
   s.required_ruby_version = ">= 2.4.0"
 
   s.authors = ["Tadayoshi Funaba"]


### PR DESCRIPTION
Remove all shipped files and require path on JRuby until we can add JRuby's extension to the gem.

Temporary workaround for #48