### PR TITLE
Migrate set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,7 +28,7 @@ jobs:
       id: diff
       run: |
         git diff --no-ext-diff --ignore-submodules --exit-code ||
-        echo "::set-output name=diff::true"
+        echo "diff=true" >> $GITHUB_OUTPUT
     - name: Commit
       run: |
         git commit --message="Update zonetab.h at $(date +%F)" ext/date


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/