### PR TITLE
Use a centralized, automatically updated set of Ruby versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,19 @@ on:
     - cron: '10 3 * * *'
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 2.6
+
   build:
     if: ${{ startsWith(github.repository, 'ruby/') || github.event_name != 'schedule' }}
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
+    needs: ruby-versions
     strategy:
       matrix:
-        ruby: [ head, '3.1', '3.0', 2.7, 2.6 ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
           - ruby: head


### PR DESCRIPTION
This is an alternative to the explicit Ruby 3.2 update that uses a centrally managed set of Rubies rather than explicitly setting Ruby versions in the CI configuration.