### PR TITLE
Use endless method definition

### DIFF
--- a/lib/date.rb
+++ b/lib/date.rb
@@ -10,27 +10,25 @@ class Date
   #   infinite? -> false
   #
   # Returns +false+
-  def infinite?
-    false
-  end
+  def infinite? = false
 
   class Infinity < Numeric # :nodoc:
 
-    def initialize(d=1) @d = d <=> 0 end
+    def initialize(d=1) = @d = d <=> 0
 
-    def d() @d end
+    def d = @d
 
     protected :d
 
-    def zero?() false end
-    def finite?() false end
-    def infinite?() d.nonzero? end
-    def nan?() d.zero? end
+    def zero? = false
+    def finite? = false
+    def infinite? = d.nonzero?
+    def nan? = d.zero?
 
-    def abs() self.class.new end
+    def abs = self.class.new
 
-    def -@() self.class.new(-d) end
-    def +@() self.class.new(+d) end
+    def -@ = self.class.new(-d)
+    def +@ = self.class.new(+d)
 
     def <=>(other)
       case other

--- a/test/date/test_date.rb
+++ b/test/date/test_date.rb
@@ -6,6 +6,10 @@ class DateSub < Date; end
 class DateTimeSub < DateTime; end
 
 class TestDate < Test::Unit::TestCase
+  def test_infinite
+    assert_equal false, Date.new.infinite?
+  end
+
   def test_range_infinite_float
     today = Date.today
     r = today...Float::INFINITY


### PR DESCRIPTION
Given that we can now use the end-less method definitions for these short methods, let use it. It removes extra characters, which means less text to parse when reading.