### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/date

### DIFF
--- a/date.gemspec
+++ b/date.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |s|
   s.email = [nil]
   s.homepage = "https://github.com/ruby/date"
   s.licenses = ["Ruby", "BSD-2-Clause"]
+
+  s.metadata["changelog_uri"] = s.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/date which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/