### PR TITLE
Remove the unintentional ability to parse `Symbol`

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -4464,12 +4464,6 @@ check_limit(VALUE str, VALUE opt)
 {
     size_t slen, limit;
     if (NIL_P(str)) return;
-    if (SYMBOL_P(str)) {
-	rb_category_warn(RB_WARN_CATEGORY_DEPRECATED,
-			 "The ability to parse Symbol is an unintentional bug and is deprecated");
-	str = rb_sym2str(str);
-    }
-
     StringValue(str);
     slen = RSTRING_LEN(str);
     limit = get_limit(opt);

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -867,9 +867,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._iso8601(nil)
     assert_equal({}, h)
 
-    h = assert_deprecated_warn {Date._iso8601('01-02-03T04:05:06Z'.to_sym)}
-    assert_equal([2001, 2, 3, 4, 5, 6, 0],
-      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+    assert_raise(TypeError) {Date._iso8601('01-02-03T04:05:06Z'.to_sym)}
   end
 
   def test__rfc3339
@@ -889,9 +887,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._rfc3339(nil)
     assert_equal({}, h)
 
-    h = assert_deprecated_warn {Date._rfc3339('2001-02-03T04:05:06Z'.to_sym)}
-    assert_equal([2001, 2, 3, 4, 5, 6, 0],
-      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+    assert_raise(TypeError) {Date._rfc3339('2001-02-03T04:05:06Z'.to_sym)}
   end
 
   def test__xmlschema
@@ -978,9 +974,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._xmlschema(nil)
     assert_equal({}, h)
 
-    h = assert_deprecated_warn {Date._xmlschema('2001-02-03'.to_sym)}
-    assert_equal([2001, 2, 3, nil, nil, nil, nil],
-      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+    assert_raise(TypeError) {Date._xmlschema('2001-02-03'.to_sym)}
   end
 
   def test__rfc2822
@@ -1017,9 +1011,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._rfc2822(nil)
     assert_equal({}, h)
 
-    h = assert_deprecated_warn {Date._rfc2822('Sat, 3 Feb 2001 04:05:06 UT'.to_sym)}
-    assert_equal([2001, 2, 3, 4, 5, 6, 0],
-      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+    assert_raise(TypeError) {Date._rfc2822('Sat, 3 Feb 2001 04:05:06 UT'.to_sym)}
   end
 
   def test__httpdate
@@ -1044,9 +1036,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._httpdate(nil)
     assert_equal({}, h)
 
-    h = assert_deprecated_warn {Date._httpdate('Sat, 03 Feb 2001 04:05:06 GMT'.to_sym)}
-    assert_equal([2001, 2, 3, 4, 5, 6, 0],
-      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+    assert_raise(TypeError) {Date._httpdate('Sat, 03 Feb 2001 04:05:06 GMT'.to_sym)}
   end
 
   def test__jisx0301
@@ -1127,9 +1117,7 @@ class TestDateParse < Test::Unit::TestCase
     h = Date._jisx0301(nil)
     assert_equal({}, h)
 
-    h = assert_deprecated_warn {Date._jisx0301('H13.02.03T04:05:06.07+0100'.to_sym)}
-    assert_equal([2001, 2, 3, 4, 5, 6, 3600],
-      h.values_at(:year, :mon, :mday, :hour, :min, :sec, :offset))
+    assert_raise(TypeError) {Date._jisx0301('H13.02.03T04:05:06.07+0100'.to_sym)}
   end
 
   def test_iso8601


### PR DESCRIPTION
It's been 2 years since ruby/date#49, so it's okay.