### PR TITLE
Fix incorrect argc2 decrement in datetime_s_iso8601 function

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -8485,7 +8485,7 @@ datetime_s_iso8601(int argc, VALUE *argv, VALUE klass)
         VALUE argv2[2], hash;
         argv2[0] = str;
         argv2[1] = opt;
-        if (!NIL_P(opt)) argc2--;
+        if (!NIL_P(opt)) argc2++;
 	hash = date_s__iso8601(argc2, argv2, klass);
 	return dt_new_by_frags(klass, hash, sg);
     }

--- a/test/date/test_date_strftime.rb
+++ b/test/date/test_date_strftime.rb
@@ -412,6 +412,14 @@ class TestDateStrftime < Test::Unit::TestCase
     assert_equal('H31.04.30', Date.parse('2019-04-30').jisx0301)
     assert_equal('R01.05.01', Date.parse('2019-05-01').jisx0301)
 
+    assert_equal(d2, DateTime.iso8601('2001-02-03T04:05:06.123456+00:00', limit: 64))
+    assert_equal(d2, DateTime.rfc3339('2001-02-03T04:05:06.123456+00:00', limit: 64))
+    assert_equal(d2, DateTime.jisx0301('H13.02.03T04:05:06.123456+00:00', limit: 64))
+
+    assert_raise(ArgumentError) { DateTime.iso8601('2001-02-03T04:05:06.123456+00:00', limit: 1) }
+    assert_raise(ArgumentError) { DateTime.rfc3339('2001-02-03T04:05:06.123456+00:00', limit: 1) }
+    assert_raise(ArgumentError) { DateTime.jisx0301('H13.02.03T04:05:06.123456+00:00', limit: 1) }
+
     %w(M06.01.01
        M45.07.29
        T01.07.30


### PR DESCRIPTION
Replace the decrement (argc2--) with an increment (argc2++) for the correct number of arguments when opt is provided.