### PR TITLE
Suppress warnings

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -8954,9 +8954,10 @@ date_to_time(VALUE self)
     get_d1a(self);
 
     if (m_julian_p(adat)) {
-        self = d_lite_gregorian(self);
-        get_d1b(self);
+        VALUE g = d_lite_gregorian(self);
+        get_d1b(g);
         adat = bdat;
+        self = g;
     }
 
     t = f_local3(rb_cTime,
@@ -9034,9 +9035,10 @@ datetime_to_time(VALUE self)
     get_d1(self);
 
     if (m_julian_p(dat)) {
-	self = d_lite_gregorian(self);
-	get_d1a(self);
+	VALUE g = d_lite_gregorian(self);
+	get_d1a(g);
 	dat = adat;
+	self = g;
     }
 
     {

--- a/ext/date/extconf.rb
+++ b/ext/date/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 
 config_string("strict_warnflags") {|w| $warnflags += " #{w}"}
 
+append_cflags("-Wno-compound-token-split-by-macro") if RUBY_VERSION < "2.7."
 have_func("rb_category_warn")
 with_werror("", {:werror => true}) do |opt, |
   have_var("timezone", "time.h", opt)


### PR DESCRIPTION
- `compound-token-split-by-macro` was used intentionally.
- ruby 2.6 uses C90, not C99.