### PR TITLE
Simplify description of this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `Date`
 
-A subclass of `Object` that includes the `Comparable` module and easily handles date.
+The official date library for Ruby.
 
 ## Installation
 

--- a/date.gemspec
+++ b/date.gemspec
@@ -7,8 +7,8 @@ end
 Gem::Specification.new do |s|
   s.name = "date"
   s.version = version
-  s.summary = "A subclass of Object includes Comparable module for handling dates."
-  s.description = "A subclass of Object includes Comparable module for handling dates."
+  s.summary = "The official date library for Ruby."
+  s.description = "The official date library for Ruby."
 
   if Gem::Platform === s.platform and s.platform =~ 'java' or RUBY_ENGINE == 'jruby'
     s.platform = 'java'


### PR DESCRIPTION
> A subclass of `Object` that includes the `Comparable` module and easily handles date.

This description felt a little _too_ academic to my eyes. I think it should be simplified to:

> The official date library for Ruby.