### PR TITLE
[DOC] Fix broken rdoc-ref to the calendar page

### DIFF
--- a/doc/date/calendars.rdoc
+++ b/doc/date/calendars.rdoc
@@ -31,7 +31,7 @@ See also {a concrete example here}[rdoc-ref:DateTime@When+should+you+use+DateTim
 === Argument +start+
 
 Certain methods in class \Date handle differences in the
-{Julian and Gregorian calendars}[rdoc-ref:calendars.rdoc@Julian+and+Gregorian+Calendars]
+{Julian and Gregorian calendars}[rdoc-ref:date/calendars.rdoc@Julian+and+Gregorian+Calendars]
 by accepting an optional argument +start+, whose value may be:
 
 - Date::ITALY (the default): the created date is Julian

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -2498,7 +2498,7 @@ date_s__valid_jd_p(int argc, VALUE *argv, VALUE klass)
  *
  *   Date.valid_jd?(2451944) # => true
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd.
  */
@@ -2592,7 +2592,7 @@ date_s__valid_civil_p(int argc, VALUE *argv, VALUE klass)
  *   Date.valid_date?(2001, 2, 29) # => false
  *   Date.valid_date?(2001, 2, -1) # => true
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd, Date.new.
  */
@@ -2680,7 +2680,7 @@ date_s__valid_ordinal_p(int argc, VALUE *argv, VALUE klass)
  *   Date.valid_ordinal?(2001, 34)  # => true
  *   Date.valid_ordinal?(2001, 366) # => false
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd, Date.ordinal.
  */
@@ -2770,7 +2770,7 @@ date_s__valid_commercial_p(int argc, VALUE *argv, VALUE klass)
  *
  * See Date.commercial.
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd, Date.commercial.
  */
@@ -3350,7 +3350,7 @@ static VALUE d_lite_plus(VALUE, VALUE);
  *
  *     Date.jd(Date::ITALY - 1).julian?    # => true
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.new.
  */
@@ -3415,7 +3415,7 @@ date_s_jd(int argc, VALUE *argv, VALUE klass)
  *
  * Raises an exception if +yday+ is zero or out of range.
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd, Date.new.
  */
@@ -3492,7 +3492,7 @@ date_s_civil(int argc, VALUE *argv, VALUE klass)
  * where +n+ is the number of days in the month;
  * when the argument is negative, counts backward from the end of the month.
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd.
  */
@@ -3598,7 +3598,7 @@ date_initialize(int argc, VALUE *argv, VALUE self)
  *     Date.commercial(2020, 1, 1).to_s # => "2019-12-30"
        Date.commercial(2020, 1, 7).to_s # => "2020-01-05"
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * Related: Date.jd, Date.new, Date.ordinal.
  */
@@ -3783,7 +3783,7 @@ static void set_sg(union DateData *, double);
  *
  *   Date.today.to_s # => "2022-07-06"
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  */
 static VALUE
@@ -4415,7 +4415,7 @@ date_s__strptime(int argc, VALUE *argv, VALUE klass)
  * {Formats for Dates and Times}[https://docs.ruby-lang.org/en/master/strftime_formatting_rdoc.html].
  * (Unlike Date.strftime, does not support flags and width.)
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  * See also {strptime(3)}[https://man7.org/linux/man-pages/man3/strptime.3.html].
  *
@@ -4560,7 +4560,7 @@ date_s__parse(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._parse (returns a hash).
@@ -4639,7 +4639,7 @@ date_s__iso8601(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._iso8601 (returns a hash).
@@ -4709,7 +4709,7 @@ date_s__rfc3339(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._rfc3339 (returns a hash).
@@ -4777,7 +4777,7 @@ date_s__xmlschema(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._xmlschema (returns a hash).
@@ -4847,7 +4847,7 @@ date_s__rfc2822(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._rfc2822 (returns a hash).
@@ -4915,7 +4915,7 @@ date_s__httpdate(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._httpdate (returns a hash).
@@ -4987,7 +4987,7 @@ date_s__jisx0301(int argc, VALUE *argv, VALUE klass)
  *
  * See:
  *
- * - Argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * - Argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  * - Argument {limit}[rdoc-ref:Date@Argument+limit].
  *
  * Related: Date._jisx0301 (returns a hash).
@@ -5745,7 +5745,7 @@ d_lite_leap_p(VALUE self)
  *   Date.new(2001, 2, 3, Date::GREGORIAN).start # => -Infinity
  *   Date.new(2001, 2, 3, Date::JULIAN).start    # => Infinity
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  */
 static VALUE
@@ -5820,7 +5820,7 @@ dup_obj_with_new_start(VALUE obj, double sg)
  *   d1 = d0.new_start(Date::JULIAN)
  *   d1.julian? # => true
  *
- * See argument {start}[rdoc-ref:calendars.rdoc@Argument+start].
+ * See argument {start}[rdoc-ref:date/calendars.rdoc@Argument+start].
  *
  */
 static VALUE
@@ -9522,7 +9522,7 @@ Init_date_core(void)
      *
      * - You need both dates and times; \Date handles only dates.
      * - You need only Gregorian dates (and not Julian dates);
-     *   see {Julian and Gregorian Calendars}[rdoc-ref:calendars.rdoc].
+     *   see {Julian and Gregorian Calendars}[rdoc-ref:date/calendars.rdoc].
      *
      * A \Date object, once created, is immutable, and cannot be modified.
      *


### PR DESCRIPTION
Detected through https://github.com/ruby/rdoc/pull/1241

The page was extracted in https://github.com/ruby/ruby/commit/1607c6d2814cc4f71aa65bc273d745f28514e735#diff-4f9ed949fe99ee2f4aa849e5df31cb792f2852d62349af6217c5f11a46fd1613 but the links weren't correct as they should have the `date/` prefix.

**Before**

<img width="60%" alt="Screenshot 2024-12-14 at 12 40 02" src="https://github.com/user-attachments/assets/2edb6be3-a9d9-4a3e-af9d-e64f7022a316" />

**After**

<img width="60%" alt="Screenshot 2024-12-14 at 12 40 33" src="https://github.com/user-attachments/assets/73f9bda1-a7ae-46f5-816b-e2f8026f54a8" />

This still needs https://github.com/ruby/ruby/pull/12346 to add `date` to `doc/.document` to appear properly in the rendered documentation.