### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby
+      engine: cruby-truffleruby
       min_version: 2.6
 
   build:
@@ -23,6 +23,14 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
           - ruby: head
+            os: windows-latest
+          - ruby: truffleruby # need truffleruby 24.2+
+            os: ubuntu-latest
+          - ruby: truffleruby # need truffleruby 24.2+
+            os: macos-latest
+          - ruby: truffleruby
+            os: windows-latest
+          - ruby: truffleruby-head
             os: windows-latest
         include:
           - ruby: mingw

--- a/test/date/test_date_conv.rb
+++ b/test/date/test_date_conv.rb
@@ -89,11 +89,14 @@ class TestDateConv < Test::Unit::TestCase
 		   [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.nsec])
     end
 
-    if Time.allocate.respond_to?(:subsec)
-      d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789123456789123.to_r/86400000000000000000000
-      t = d.to_time.utc
-      assert_equal([2004, 9, 19, 1, 2, 3, Rational(456789123456789123,1000000000000000000)],
-		   [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.subsec])
+    # TruffleRuby does not support more than nanoseconds
+    unless RUBY_ENGINE == 'truffleruby'
+      if Time.allocate.respond_to?(:subsec)
+        d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789123456789123.to_r/86400000000000000000000
+        t = d.to_time.utc
+        assert_equal([2004, 9, 19, 1, 2, 3, Rational(456789123456789123,1000000000000000000)],
+         [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.subsec])
+      end
     end
   end
 

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -589,10 +589,13 @@ class TestDateParse < Test::Unit::TestCase
   end
 
   def test__parse_too_long_year
-    str = "Jan 1" + "0" * 100_000
-    h = EnvUtil.timeout(3) {Date._parse(str, limit: 100_010)}
-    assert_equal(100_000, Math.log10(h[:year]))
-    assert_equal(1, h[:mon])
+    # Math.log10 does not support so big numbers like 10^100_000 on TruffleRuby
+    unless RUBY_ENGINE == 'truffleruby'
+      str = "Jan 1" + "0" * 100_000
+      h = EnvUtil.timeout(3) {Date._parse(str, limit: 100_010)}
+      assert_equal(100_000, Math.log10(h[:year]))
+      assert_equal(1, h[:mon])
+    end
 
     str = "Jan - 1" + "0" * 100_000
     h = EnvUtil.timeout(3) {Date._parse(str, limit: 100_010)}


### PR DESCRIPTION
Wondering if maintainers are open to have TruffleRuby in date's CI.

The current TruffleRuby release doesn't support the `date` gem well because of missing `rb_str_format` function. Now this issue is resolved on TruffleRuby master (https://github.com/oracle/truffleruby/issues/3716, but it isn't released yet). So I propose to add temporary TruffleRuby head and switch to TruffleRuby release when TruffleRuby 24.2 is coming out.