### PR TITLE
Enclose dangling else in braces and fix -Wmisleading-indentation

### DIFF
--- a/ext/date/date_strptime.c
+++ b/ext/date/date_strptime.c
@@ -122,8 +122,9 @@ do { \
 do { \
     size_t l; \
     l = read_digits(&str[si], slen - si, &n, w); \
-    if (l == 0) \
+    if (l == 0) { \
 	fail();	\
+    } \
     si += l; \
 } while (0)
 


### PR DESCRIPTION
```
date_strptime.c:253:324: warning: misleading indentation;
      statement is not part of the previous 'if' [-Wmisleading-indentation]
  253 |   ...((VALUE)RUBY_Qtrue)); return 0; } while (0); si += l; } while (0);
      |                                                   ^
date_strptime.c:252:7: note: previous statement is here
  252 |       else
      |       ^
```