### PR TITLE
fix: Date#hash for large years

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6936,13 +6936,24 @@ d_lite_eql_p(VALUE self, VALUE other)
 static VALUE
 d_lite_hash(VALUE self)
 {
-    st_index_t v, h[4];
+    st_index_t v, h[5];
+    VALUE nth;
 
     get_d1(self);
-    h[0] = m_nth(dat);
-    h[1] = m_jd(dat);
-    h[2] = m_df(dat);
-    h[3] = m_sf(dat);
+    nth = m_nth(dat);
+
+    if (FIXNUM_P(nth)) {
+        h[0] = 0;
+        h[1] = (st_index_t)nth;
+    } else {
+        h[0] = 1;
+        h[1] = (st_index_t)FIX2LONG(rb_hash(nth));
+    }
+
+    h[2] = m_jd(dat);
+    h[3] = m_df(dat);
+    h[4] = m_sf(dat);
+
     v = rb_memhash(h, sizeof(h));
     return ST2FIX(v);
 }

--- a/test/date/test_date.rb
+++ b/test/date/test_date.rb
@@ -135,6 +135,10 @@ class TestDate < Test::Unit::TestCase
     assert_equal(9, h[DateTime.new(1999,5,25)])
 
     h = {}
+    h[Date.new(3171505571716611468830131104691,2,19)] = 0
+    assert_equal(true, h.key?(Date.new(3171505571716611468830131104691,2,19)))
+
+    h = {}
     h[DateTime.new(1999,5,23)] = 0
     h[DateTime.new(1999,5,24)] = 1
     h[DateTime.new(1999,5,25)] = 2


### PR DESCRIPTION
Addresses https://bugs.ruby-lang.org/issues/21437