### PR TITLE
fix: check for fixnum lower bound in m_ajd

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -1599,7 +1599,7 @@ m_ajd(union DateData *x)
 
     if (simple_dat_p(x)) {
 	r = m_real_jd(x);
-	if (FIXNUM_P(r) && FIX2LONG(r) <= (FIXNUM_MAX / 2)) {
+	if (FIXNUM_P(r) && FIX2LONG(r) <= (FIXNUM_MAX / 2) && FIX2LONG(r) >= (FIXNUM_MIN + 1) / 2) {
 	    long ir = FIX2LONG(r);
 	    ir = ir * 2 - 1;
 	    return rb_rational_new2(LONG2FIX(ir), INT2FIX(2));

--- a/test/date/test_switch_hitter.rb
+++ b/test/date/test_switch_hitter.rb
@@ -97,6 +97,11 @@ class TestSH < Test::Unit::TestCase
 		 [d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.offset])
   end
 
+  def test_ajd
+    assert_equal(Date.civil(2008, 1, 16).ajd, 4908963r/2)
+    assert_equal(Date.civil(-11082381539297990, 2, 19).ajd, -8095679714453739481r/2)
+  end
+
   def test_ordinal
     d = Date.ordinal
     assert_equal([-4712, 1], [d.year, d.yday])


### PR DESCRIPTION
Issue - https://bugs.ruby-lang.org/issues/21436

Apparently, the lower bound check is missing, which results in overflow & wrapping later on in RB_INT2FIX