### PR TITLE
Remove references to FL_EXIVAR

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -7517,10 +7517,7 @@ d_lite_marshal_dump_old(VALUE self)
 		    m_of_in_day(dat),
 		    DBL2NUM(m_sg(dat)));
 
-    if (FL_TEST(self, FL_EXIVAR)) {
-	rb_copy_generic_ivar(a, self);
-	FL_SET(a, FL_EXIVAR);
-    }
+    rb_copy_generic_ivar(a, self);
 
     return a;
 }
@@ -7542,10 +7539,8 @@ d_lite_marshal_dump(VALUE self)
 		    INT2FIX(m_of(dat)),
 		    DBL2NUM(m_sg(dat)));
 
-    if (FL_TEST(self, FL_EXIVAR)) {
-	rb_copy_generic_ivar(a, self);
-	FL_SET(a, FL_EXIVAR);
-    }
+
+    rb_copy_generic_ivar(a, self);
 
     return a;
 }
@@ -7618,10 +7613,7 @@ d_lite_marshal_load(VALUE self, VALUE a)
 		       HAVE_JD | HAVE_DF);
     }
 
-    if (FL_TEST(a, FL_EXIVAR)) {
-	rb_copy_generic_ivar(self, a);
-	FL_SET(self, FL_EXIVAR);
-    }
+    rb_copy_generic_ivar(a, self);
 
     return self;
 }


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/pull/13612

This flag isn't really meant to be public, it's an implementation detail of Ruby.

And checking it before calling `rb_copy_generic_ivar` only save a function call.

