### PR TITLE
Remove archaic conditions

### DIFF
--- a/test/date/test_date_conv.rb
+++ b/test/date/test_date_conv.rb
@@ -82,21 +82,17 @@ class TestDateConv < Test::Unit::TestCase
     assert_equal([1582, 10, 13, 1, 2, 3, 456789],
 		 [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.usec])
 
-    if Time.method_defined?(:nsec)
-      d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789123.to_r/86400000000000
-      t = d.to_time.utc
-      assert_equal([2004, 9, 19, 1, 2, 3, 456789123],
-		   [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.nsec])
-    end
+    d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789123.to_r/86400000000000
+    t = d.to_time.utc
+    assert_equal([2004, 9, 19, 1, 2, 3, 456789123],
+		 [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.nsec])
 
     # TruffleRuby does not support more than nanoseconds
     unless RUBY_ENGINE == 'truffleruby'
-      if Time.method_defined?(:subsec)
-        d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789123456789123.to_r/86400000000000000000000
-        t = d.to_time.utc
-        assert_equal([2004, 9, 19, 1, 2, 3, Rational(456789123456789123,1000000000000000000)],
-         [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.subsec])
-      end
+      d = DateTime.new(2004, 9, 19, 1, 2, 3, 0) + 456789123456789123.to_r/86400000000000000000000
+      t = d.to_time.utc
+      assert_equal([2004, 9, 19, 1, 2, 3, Rational(456789123456789123,1000000000000000000)],
+                   [t.year, t.mon, t.mday, t.hour, t.min, t.sec, t.subsec])
     end
   end
 


### PR DESCRIPTION
`Time#nsec` and `Time#subsec` were both introduced in Ruby 1.9.
