### PR TITLE
Add truffleruby in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     needs: ruby-versions
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -29,6 +30,8 @@ jobs:
             os: windows-latest
           - ruby: mswin
             os: windows-2022
+          - ruby: truffleruby
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6

--- a/test/date/test_date_parse.rb
+++ b/test/date/test_date_parse.rb
@@ -591,13 +591,7 @@ class TestDateParse < Test::Unit::TestCase
   end
 
   def test__parse_too_long_year
-    # Math.log10 does not support so big numbers like 10^100_000 on TruffleRuby
-    unless RUBY_ENGINE == 'truffleruby'
-      str = "Jan 1" + "0" * 100_000
-      h = EnvUtil.timeout(3) {Date._parse(str, limit: 100_010)}
-      assert_equal(100_000, Math.log10(h[:year]))
-      assert_equal(1, h[:mon])
-    end
+    omit 'transient' if RUBY_ENGINE == 'truffleruby'
 
     str = "Jan - 1" + "0" * 100_000
     h = EnvUtil.timeout(3) {Date._parse(str, limit: 100_010)}


### PR DESCRIPTION
Originally added in https://github.com/ruby/date/pull/115

Removed in https://github.com/ruby/date/commit/037e9173510e26014aad1b8a2ae7d21c4a6a3363
Probably because of the [failures around that time](https://github.com/ruby/date/actions/workflows/test.yml?page=5).
All failures on this page are:
```
Error: test__parse_too_long_year(TestDateParse): Timeout::Error: execution expired
/home/runner/.rubies/truffleruby-head/lib/mri/timeout.rb:40:in 'Timeout::Error.handle_timeout'
/home/runner/.rubies/truffleruby-head/lib/mri/timeout.rb:198:in 'Timeout#timeout'
/home/runner/work/date/date/vendor/bundle/truffleruby/3.4.7.10/gems/test-unit-ruby-core-1.0.14/lib/envutil.rb:78:in 'EnvUtil#timeout'
/home/runner/work/date/date/test/date/test_date_parse.rb:603:in 'TestDateParse#test__parse_too_long_year'
     600:     end
     601: 
     602:     str = "Jan - 1" + "0" * 100_000
  => 603:     h = EnvUtil.timeout(3) {Date._parse(str, limit: 100_010)}
     604:     assert_equal(1, h[:mon])
     605:     assert_not_include(h, :year)
     606:   end
<internal:core> core/throw_catch.rb:36:in 'Kernel#catch'
<internal:core> core/throw_catch.rb:36:in 'Kernel#catch'
Error: Timeout::Error: execution expired
/home/runner/.rubies/truffleruby-head/lib/mri/timeout.rb:40:in 'Timeout::Error.handle_timeout'
/home/runner/.rubies/truffleruby-head/lib/mri/timeout.rb:198:in 'Timeout#timeout'
/home/runner/work/date/date/vendor/bundle/truffleruby/3.4.7.10/gems/test-unit-ruby-core-1.0.14/lib/envutil.rb:78:in 'EnvUtil#timeout'
/home/runner/work/date/date/test/date/test_date_parse.rb:603:in 'TestDateParse#test__parse_too_long_year'
```

This test is now omitted on TruffleRuby to avoid failures.

I'll also look into setting the `timeout_scale` in https://github.com/ruby/test-unit-ruby-core.