### PR TITLE
Fix stray bracket in Date#new_start call-seq

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6003,7 +6003,7 @@ dup_obj_with_new_start(VALUE obj, double sg)
 
 /*
  * call-seq:
- *   new_start(start = Date::ITALY]) -> new_date
+ *   new_start(start = Date::ITALY) -> new_date
  *
  * Returns a copy of +self+ with the given +start+ value:
  *


### PR DESCRIPTION
The `call-seq` for `Date#new_start` had a stray `]` after `Date::ITALY`. Documentation only, no behavior change.