### PR TITLE
Range-check the integral Rational offset

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -2621,9 +2621,9 @@ offset_to_sec(VALUE vof, int *rof)
 		if (!FIXNUM_P(vn))
 		    return 0;
 		n = FIX2LONG(vn);
-		if (n < -DAY_IN_SECONDS || n > DAY_IN_SECONDS)
-		    return 0;
 	    }
+	    if (n < -DAY_IN_SECONDS || n > DAY_IN_SECONDS)
+		return 0;
 	    *rof = (int)n;
 	    return 1;
 	}

--- a/test/date/test_date_new.rb
+++ b/test/date/test_date_new.rb
@@ -199,11 +199,17 @@ class TestDateNew < Test::Unit::TestCase
     assert_equal(-1.to_r, d.offset)
 
     # An out-of-range offset is ignored, as it is for the equivalent Integer.
-    d = DateTime.civil(2001,2,3, 0,0,0, 2)
+    assert_warning(/invalid offset/) do
+      d = DateTime.civil(2001,2,3, 0,0,0, 2)
+    end
     assert_equal(0, d.offset)
-    d = DateTime.civil(2001,2,3, 0,0,0, Rational(2, 1))
+    assert_warning(/invalid offset/) do
+      d = DateTime.civil(2001,2,3, 0,0,0, Rational(2, 1))
+    end
     assert_equal(0, d.offset)
-    d = DateTime.civil(2001,2,3, 0,0,0, Rational(49710, 1))
+    assert_warning(/invalid offset/) do
+      d = DateTime.civil(2001,2,3, 0,0,0, Rational(49710, 1))
+    end
     assert_equal(0, d.offset)
   end
 

--- a/test/date/test_date_new.rb
+++ b/test/date/test_date_new.rb
@@ -192,6 +192,21 @@ class TestDateNew < Test::Unit::TestCase
     end
   end
 
+  def test_civil__offset
+    d = DateTime.civil(2001,2,3, 0,0,0, Rational(1, 1))
+    assert_equal(1.to_r, d.offset)
+    d = DateTime.civil(2001,2,3, 0,0,0, Rational(-1, 1))
+    assert_equal(-1.to_r, d.offset)
+
+    # An out-of-range offset is ignored, as it is for the equivalent Integer.
+    d = DateTime.civil(2001,2,3, 0,0,0, 2)
+    assert_equal(0, d.offset)
+    d = DateTime.civil(2001,2,3, 0,0,0, Rational(2, 1))
+    assert_equal(0, d.offset)
+    d = DateTime.civil(2001,2,3, 0,0,0, Rational(49710, 1))
+    assert_equal(0, d.offset)
+  end
+
   def test_civil__reform
     d = Date.jd(Date::ENGLAND, Date::ENGLAND)
     dt = DateTime.jd(Date::ENGLAND, 0,0,0,0, Date::ENGLAND)


### PR DESCRIPTION
## Summary

Fixes #181.

`offset_to_sec` range-checks the resulting number of seconds in every branch
except one path through the Rational branch. When the day fraction is an
integral Rational, `n` is assigned inside the `if` arm and reaches `*rof`
without passing the `n < -DAY_IN_SECONDS || n > DAY_IN_SECONDS` guard that
sits in the `else` arm.

```ruby
DateTime.new(2024, 1, 1, 0, 0, 0, 2).iso8601                  # => "2024-01-01T00:00:00+00:00"
DateTime.new(2024, 1, 1, 0, 0, 0, Rational(2, 1)).iso8601     # => "2024-01-01T00:00:00+48:00"
DateTime.new(2024, 1, 1, 0, 0, 0, Rational(49710, 1)).iso8601 # => "2024-01-01T00:00:00-06:28"
```

The Integer `2` is rejected and falls back to `+00:00`, but `Rational(2, 1)` is
the same quantity and yields a 48-hour offset. `Rational(49710, 1)` is
4_294_944_000 seconds, over `INT_MAX`, so the `(int)` narrowing turns a large
positive offset into a negative one.

## Changes

- Move the existing range check below the `if`/`else` in `offset_to_sec` so it
  covers both arms. This is the same check the `T_FIXNUM`, `T_FLOAT` and
  `T_STRING` branches already apply, and it bounds `n` before the `long` to
  `int` narrowing. The `rounded:` label path falls through to it as well.
- Add `test_civil__offset` covering the three values above plus the in-range
  boundary. `Rational(1, 1)` is exactly `DAY_IN_SECONDS` and the guard is
  inclusive, so `±24:00` still round-trips.

After the change all three expressions above produce `+00:00`, matching the
Integer path, and the constructor emits the usual `invalid offset is ignored`
warning.

## Testing

- `bundle exec rake compile`
- `bundle exec rake test` — 145 tests, 162600 assertions, 0 failures (144 tests
  before the new one; it fails on master and passes with the fix)
- `bundle exec rake` — exit 0

Run on ruby 4.0.6 (arm64-darwin25) against 83eb9d4.