### PR TITLE
Validate the commercial week range before conversion

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -992,11 +992,15 @@ c_valid_commercial_p(int y, int w, int d, double sg,
     if (w < 0) {
 	int rjd2;
 
+	if (w < -53) return 0;
 	c_commercial_to_jd(y + 1, 1, 1, sg, &rjd2, &ns2);
 	c_jd_to_commercial(rjd2 + w * 7, sg, &ry2, &rw2, &rd2);
 	if (ry2 != y)
 	    return 0;
 	w = rw2;
+    }
+    else {
+	if (w < 1 || 53 < w) return 0;
     }
     c_commercial_to_jd(y, w, d, sg, rjd, ns);
     c_jd_to_commercial(*rjd, sg, &ry2, rw, rd);

--- a/test/date/test_date_new.rb
+++ b/test/date/test_date_new.rb
@@ -256,6 +256,11 @@ class TestDateNew < Test::Unit::TestCase
     end
   end
 
+  def test_commercial_p
+    assert_equal(false, Date.valid_commercial?(2024, -53, 1))
+    assert_equal(false, Date.valid_commercial?(2024, -1227133565, 1))
+  end
+
   def test_weeknum
     d = Date.weeknum
     dt = DateTime.weeknum


### PR DESCRIPTION
Reject week numbers outside -53..-1 and 1..53 before conversion so integer overflow cannot make invalid input appear valid.

Fixes #180.